### PR TITLE
new emojis and emoticons - bug fixed for nonexisting emoticons

### DIFF
--- a/emot/core.py
+++ b/emot/core.py
@@ -68,6 +68,7 @@ def emoticons(string):
         __entities = []
         __value = []
         __location = []
+
         matches = re.finditer(r"%s"%pattern,str(string))
         for et in matches:
             __value.append(et.group().strip())
@@ -75,7 +76,16 @@ def emoticons(string):
             
         __mean = []
         for each in __value:
-            __mean.append(emo_unicode.EMOTICONS_EMO[each])
+            __mean.append(emo_unicode.EMOTICONS_EMO.get(each))
+            
+        try:
+            while True:
+                ix = __mean.index(None)
+                __mean.pop(ix)
+                __value.pop(ix)
+                __location.pop(ix)
+        except ValueError as e:
+            pass
         
         if len(__value) < 1:
             flag = False

--- a/emot/emo_unicode.py
+++ b/emot/emo_unicode.py
@@ -10,7 +10,11 @@ __all__ = ['EMO_UNICODE', 'UNICODE_EMO', 'EMOTICONS', 'EMOTICONS_EMO']
 
 EMOTICONS = {
     u":‑\)":"Happy face or smiley",
+    u":-\)\)":"Very Happy face or smiley",
+    u":-\)\)\)":"Very very Happy face or smiley",
     u":\)":"Happy face or smiley",
+    u":\)\)":"Very Happy face or smiley",
+    u":\)\)\)":"Very very Happy face or smiley",
     u":-\]":"Happy face or smiley",
     u":\]":"Happy face or smiley",
     u":-3":"Happy face smiley",
@@ -2619,13 +2623,20 @@ EMO_UNICODE = {
     u':zipper-mouth_face:': u'\U0001F910',
     u':zzz:': u'\U0001F4A4',
     u':Åland_Islands:': u'\U0001F1E6 \U0001F1FD',
+    u':smiling_face_with_three_hearts:': u'\U0001F970',
+    u':orange_heart:': u'U0001F9E1',
+    u':pleading_face:': u'U0001F97A',
 }
 
 UNICODE_EMO = {v: k for k, v in EMO_UNICODE.items()}
 
 EMOTICONS_EMO = {
     u":‑)":"Happy face or smiley",
+    u":-))":"Very Happy face or smiley",
+    u":-)))":"Very very Happy face or smiley",
     u":)":"Happy face or smiley",
+    u":))":"Very Happy face or smiley",
+    u":)))":"Very very Happy face or smiley",
     u":-]":"Happy face or smiley",
     u":]":"Happy face or smiley",
     u":-3":"Happy face smiley",


### PR DESCRIPTION
Hi,
regex pattern for emoticons was catching () and ) although these did not have meaning on the dictionary. It was not easy to find why these were caught but it is easier to pop them out if not found on the emoticons dictionary. 
There were three emojis missing in my case, so added them to the dictionary.
