### PR TITLE
Change imports in core.py

### DIFF
--- a/emot/core.py
+++ b/emot/core.py
@@ -1,7 +1,6 @@
 try:
-    import emo_unicode
+    from . import emo_unicode, pattern_generator
     import re
-    import pattern_generator
     import multiprocessing as mp
 except Exception as E:
     print("Issue with loading of the library: " + str(E))


### PR DESCRIPTION
## Change imports in core.py

### Description:

- Explain error: Unable to import the package at all.
- Code: `import emot`
- Error output: `Issue with loading of the library: No module named emo_unicode`, followed by `NameError: name 'mp' is not defined`

The error is likely originating within the try/except import block in core.py. I implemented a fix that uses relative import.



